### PR TITLE
Fix the URL to the xcframework for 1.11.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     targets: [
         .binaryTarget(
             name: "TinkCore",
-            url: "https://github.com/tink-ab/tink-core-ios/releases/download/1.10.0/TinkCore.xcframework.zip", checksum: "a75f6a8e08bff48411cff889635761960245c582da1ad98911039201c0b2305f"
+            url: "https://github.com/tink-ab/tink-core-ios/releases/download/1.11.0/TinkCore.xcframework.zip", checksum: "a75f6a8e08bff48411cff889635761960245c582da1ad98911039201c0b2305f"
         ),
     ]
 )


### PR DESCRIPTION
Fix the URL to the xcframework for 1.11.0